### PR TITLE
Fixing Filament V3 compatibility

### DIFF
--- a/resources/views/kanban-board.blade.php
+++ b/resources/views/kanban-board.blade.php
@@ -18,7 +18,7 @@
             </div>
 
             <div wire:ignore>
-                @includeWhen($sortable, 'filament-kanban-board::sortable', [
+                @includeWhen($sortable, $sortableView, [
                     'sortable' => $sortable,
                     'sortableBetweenStatuses' => $sortableBetweenStatuses,
                 ])

--- a/resources/views/sortable.blade.php
+++ b/resources/views/sortable.blade.php
@@ -1,6 +1,8 @@
 <script>
     window.onload = () => {
         @foreach($statuses as $status)
+
+        {{-- Added space to fix issues with Livewire cutting off some code with comment block in livewire 3 and filament 3--}}
         Sortable.create(document.getElementById('{{ $status['kanbanRecordsId'] }}'), {
             group: '{{ $sortableBetweenStatuses ? $status['group'] : $status['id'] }}',
             animation: 0,
@@ -34,6 +36,7 @@
                 Livewire.emit('onStatusChanged', recordId, toStatusId, fromOrderedIds, toOrderedIds);
             },
         });
+
         @endforeach
     }
 </script>


### PR DESCRIPTION
This PR includes 2 things:

1. Fixed missing variable usage in the template.
2. Fixed Sorting workflow as it was broken due to Livewire 3 workflows.

---

Missing variable:

While this is not a bug - it still did not allow to override a single template. This would have been useful as you can then modify what is inside the template to your liking.

---

Livewire broken workflow:

This issue was a bit strange, but I encountered a console error (browser) saying that JSON was invalid:

![image](https://github.com/invaders-xx/filament-kanban-board/assets/3809773/9852ccb3-5abe-49b9-bca1-162d95e895bb)

This resulted in this line having an issue:

![image](https://github.com/invaders-xx/filament-kanban-board/assets/3809773/daca5c96-f912-4957-b591-0e1678f699ee)

If we take a look closer, Livewire has added a comment before... For whatever reason:

![image](https://github.com/invaders-xx/filament-kanban-board/assets/3809773/aedd95c0-5dae-46f6-a29d-c1d279144305)

This made it unusable. So, introducing a space after:

```
        @foreach($statuses as $status)
```

Solves this issue:


![image](https://github.com/invaders-xx/filament-kanban-board/assets/3809773/12bffd68-9887-49a2-9901-6fa102180420)

