### PR TITLE
Use dispatch instead of emit

### DIFF
--- a/resources/views/sortable.blade.php
+++ b/resources/views/sortable.blade.php
@@ -26,14 +26,14 @@
                 const fromOrderedIds = [].slice.call(evt.from.children).map(child => child.id);
 
                 if (sameContainer) {
-                    Livewire.dispatch('onStatusSorted', {recordId, fromStatusId, fromOrderedIds});
+                    Livewire.dispatch('onStatusSorted', {recordId, statusId: fromStatusId, orderedIds: fromOrderedIds});
                     return;
                 }
 
                 const toStatusId = evt.to.dataset.statusId;
                 const toOrderedIds = [].slice.call(evt.to.children).map(child => child.id);
 
-                Livewire.dispatch('onStatusChanged', {recordId, toStatusId, fromOrderedIds, toOrderedIds});
+                Livewire.dispatch('onStatusChanged', {recordId, statusId: toStatusId, fromOrderedIds, toOrderedIds});
             },
         });
 

--- a/resources/views/sortable.blade.php
+++ b/resources/views/sortable.blade.php
@@ -26,14 +26,14 @@
                 const fromOrderedIds = [].slice.call(evt.from.children).map(child => child.id);
 
                 if (sameContainer) {
-                    Livewire.emit('onStatusSorted', recordId, fromStatusId, fromOrderedIds);
+                    Livewire.dispatch('onStatusSorted', recordId, fromStatusId, fromOrderedIds);
                     return;
                 }
 
                 const toStatusId = evt.to.dataset.statusId;
                 const toOrderedIds = [].slice.call(evt.to.children).map(child => child.id);
 
-                Livewire.emit('onStatusChanged', recordId, toStatusId, fromOrderedIds, toOrderedIds);
+                Livewire.dispatch('onStatusChanged', recordId, toStatusId, fromOrderedIds, toOrderedIds);
             },
         });
 

--- a/resources/views/sortable.blade.php
+++ b/resources/views/sortable.blade.php
@@ -26,14 +26,14 @@
                 const fromOrderedIds = [].slice.call(evt.from.children).map(child => child.id);
 
                 if (sameContainer) {
-                    Livewire.dispatch('onStatusSorted', recordId, fromStatusId, fromOrderedIds);
+                    Livewire.dispatch('onStatusSorted', {recordId, fromStatusId, fromOrderedIds});
                     return;
                 }
 
                 const toStatusId = evt.to.dataset.statusId;
                 const toOrderedIds = [].slice.call(evt.to.children).map(child => child.id);
 
-                Livewire.dispatch('onStatusChanged', recordId, toStatusId, fromOrderedIds, toOrderedIds);
+                Livewire.dispatch('onStatusChanged', {recordId, toStatusId, fromOrderedIds, toOrderedIds});
             },
         });
 


### PR DESCRIPTION
in `sortable.blade.php` view we have `Livewire.emit` which is not available anymore in Livewire v3, and is replaced by `dispatch`.
This causes the following error in js:
```
prospect-dashboard:673 Uncaught TypeError: Livewire.emit is not a function
    at q.onEnd (prospect-dashboard:673:26)
```