### PR TITLE
Pass model id to edit record

### DIFF
--- a/src/Forms/EditModalRecord.php
+++ b/src/Forms/EditModalRecord.php
@@ -18,6 +18,18 @@ trait EditModalRecord
         // Override this function and do whatever you want with $data
     }
 
+    public function onRecordClick($recordId, $data): void
+    {
+        $this->editModalRecord->fill($this->getModalData($recordId, $data));
+        
+        $this->dispatchBrowserEvent('open-modal', ['id' => 'kanban--edit-modal-record']);
+    }
+
+    public function getModalData($recordId, $data): array
+    {
+        return $data;
+    }
+
     protected static function getEditModalRecordSchema(): array
     {
         return [];

--- a/src/Forms/EditModalRecord.php
+++ b/src/Forms/EditModalRecord.php
@@ -5,6 +5,7 @@ namespace InvadersXX\FilamentKanbanBoard\Forms;
 trait EditModalRecord
 {
     public $editModalRecordState = [];
+    public $editModalRecordId;
 
     public function onEditRecordSubmit(): void
     {
@@ -20,8 +21,10 @@ trait EditModalRecord
 
     public function onRecordClick($recordId, $data): void
     {
-        $this->editModalRecord->fill($this->getModalData($recordId, $data));
+        $this->editModalRecordId = $recordId;
         
+        $this->editModalRecord->fill($this->getModalData($recordId, $data));
+
         $this->dispatchBrowserEvent('open-modal', ['id' => 'kanban--edit-modal-record']);
     }
 

--- a/src/Forms/EditModalRecord.php
+++ b/src/Forms/EditModalRecord.php
@@ -9,12 +9,12 @@ trait EditModalRecord
 
     public function onEditRecordSubmit(): void
     {
-        $this->editRecord($this->editModalRecord->getState());
+        $this->editRecord($this->editModalRecordId, $this->editModalRecord->getState());
 
         $this->dispatchBrowserEvent('close-modal', ['id' => 'kanban--edit-modal-record']);
     }
 
-    public function editRecord(array $data): void
+    public function editRecord($recordId, array $data): void
     {
         // Override this function and do whatever you want with $data
     }

--- a/src/Pages/FilamentKanbanBoard.php
+++ b/src/Pages/FilamentKanbanBoard.php
@@ -49,7 +49,13 @@ class FilamentKanbanBoard extends Page implements HasForms
 
     public function onRecordClick($recordId, $data): void
     {
-        //
+        $this->editModalRecord->fill($this->getModalData($recordId, $data));
+        $this->dispatchBrowserEvent('open-modal', ['id' => 'kanban--edit-modal-record']);
+    }
+
+    public function getModalData($recordId, $data): array
+    {
+        return $data;
     }
 
     protected function getViewData(): array

--- a/src/Pages/FilamentKanbanBoard.php
+++ b/src/Pages/FilamentKanbanBoard.php
@@ -47,17 +47,6 @@ class FilamentKanbanBoard extends Page implements HasForms
         //
     }
 
-    public function onRecordClick($recordId, $data): void
-    {
-        $this->editModalRecord->fill($this->getModalData($recordId, $data));
-        $this->dispatchBrowserEvent('open-modal', ['id' => 'kanban--edit-modal-record']);
-    }
-
-    public function getModalData($recordId, $data): array
-    {
-        return $data;
-    }
-
     protected function getViewData(): array
     {
         $statuses = $this->statuses();

--- a/src/Pages/FilamentKanbanBoard.php
+++ b/src/Pages/FilamentKanbanBoard.php
@@ -7,11 +7,10 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Pages\Page;
 use Illuminate\Support\Collection;
 use InvadersXX\FilamentKanbanBoard\Concerns\InteractsWithEditRecordModal;
-use InvadersXX\FilamentKanbanBoard\Forms\EditModalRecord;
 
 class FilamentKanbanBoard extends Page implements HasForms
 {
-    use InteractsWithForms, EditModalRecord, InteractsWithEditRecordModal{
+    use InteractsWithForms, InteractsWithEditRecordModal {
         InteractsWithEditRecordModal::getForms insteadof InteractsWithForms;
     }
     protected static string $view = 'filament-kanban-board::kanban-board';


### PR DESCRIPTION
The main goal of this PR is to make the record id available to the `editRecord` method, so you can fetch the model and update it. I don't know how you can persist data without having the model id in the first place.

This is technically a breaking change because it changes the method signature, but I doubt the `editRecord` was useful before this, so it shouldn't practically "break" anything.

Here are a list of changes I made:
- I've removed an unnecessary trait import (the `InteractsWithEditRecordModal` trait already imports `EditModalRecord` so it was redundant)
- I've made the `onRecordClick` method more modular by calling a noop method inside it, which is simpler to override, than having to override the actual method and dispatching browser events in your override.
- I moved code that is related to edit modal to the relevant trait.
- I save the id of the model that's being edited when the modal is shown, and I pass it to `editRecord` method so the user can actually update the model.

Let me know if I'm missing something here.